### PR TITLE
add test for AI generate API key endpoint

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import cors from 'cors';
+import testGenerateRouter from './testGenerate.js';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
 dotenv.config();
@@ -12,7 +13,10 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-const genAI = new GoogleGenerativeAI(process.env.API_KEY);
+// route testing testgenerate.js
+app.use("/api/test", testGenerateRouter);
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 const model = genAI.getGenerativeModel({ model: 'models/gemini-2.5-flash' });
 
 app.post('/api/chat', async (req, res) => {
@@ -38,18 +42,11 @@ app.post('/api/chat', async (req, res) => {
 
   try {
     const result = await model.generateContent([message]);
-    const response = result.response;
-    let replyText = response.text();
-
-    // Hapus karakter *#
-  replyText = replyText.replace(/[*#]/g, '');
-
+    let replyText = result.response.text().replace(/[*#]/g, '');
     return res.json({ reply: replyText });
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`🚀 Server ready at http://localhost:${PORT}`);
-});
+app.listen(PORT, () => console.log(`🚀 Server ready at http://localhost:${PORT}`));

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "cors": "^2.8.5",
-        "dotenv": "^17.2.1",
+        "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "react-helmet": "^6.1.0"
       },
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "cors": "^2.8.5",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "react-helmet": "^6.1.0"
   },

--- a/Backend/testGenerate.js
+++ b/Backend/testGenerate.js
@@ -1,0 +1,47 @@
+//buat test generate AI (route: /api/test/generate)
+
+import express from "express";
+import dotenv from "dotenv";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+dotenv.config();
+
+const router = express.Router();
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+
+// Route untuk testing AI Generate
+router.post("/generate", async (req, res) => {
+  try {
+    const model = genAI.getGenerativeModel({
+      model: "models/gemini-2.5-flash",
+    });
+
+    // Ambil prompt dari user
+    const message = req.body.prompt || "buatkan teks acak untuk testing";
+
+    // Tambahin konteks 
+    const prompt = `
+    Kamu adalah asisten AI yang menjawab dengan Bahasa Indonesia yang alami dan sopan.
+    Tulis hasil yang singkat, jelas, dan mudah dibaca.
+
+    Permintaan pengguna:
+    ${message}
+    `;
+
+    const result = await model.generateContent([prompt]);
+    let replyText = result.response.text();
+
+    // Bersihkan karakter aneh 
+    replyText = replyText
+      .replace(/[*#]/g, "")
+      .replace(/\n{2,}/g, "\n\n")
+      .trim();
+
+    return res.json({ reply: replyText });
+  } catch (err) {
+    console.error("Error saat generate:", err.message);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
Menambahkan file testGenerate.js untuk endpoint testing AI generate API key.
Endpoint ini: http://localhost:5000/api/test/generate
Tujuannya untuk mengetes output AI secara terpisah tanpa memengaruhi file utama.
Sedikit perubahan juga dilakukan di index.js untuk integrasi router test.